### PR TITLE
config: Overwrite config.User when env var GITHUB_USER exists

### DIFF
--- a/config
+++ b/config
@@ -23,8 +23,8 @@ clonedir ./_clone
 
 # GitHub credentials. Will also be loaded from environment (GITHUB_USER,
 # GITHUB_PASS).
-user Carpetsmoker
-pass  # export GITHUB_PASS
+# user someGitUser
+# pass  someApiToken
 
 # Add --depth=1 to git clone
 shallow-clone yes

--- a/github.go
+++ b/github.go
@@ -15,11 +15,6 @@ type repository struct {
 	Topics   []string  `json:"topics"`
 }
 
-type info struct {
-	PublicRepos  int `json:"public_repos"`
-	PrivateRepos int `json:"total_private_repos"`
-}
-
 func listRepos(org string) ([]repository, error) {
 	var repos []repository
 	err := hubhub.Paginate(&repos, "GET", "/orgs/"+org+"/repos", 0)

--- a/godocgen.go
+++ b/godocgen.go
@@ -109,7 +109,7 @@ func start() error {
 		}
 
 		repos = filterRepos(repos)
-		err = updateRepos(*c, repos)
+		err = updateRepos(c, repos)
 		if err != nil {
 			return fmt.Errorf("cannot update repo: %v", err)
 		}
@@ -143,29 +143,29 @@ func start() error {
 		return fmt.Errorf("could not copy to %v: %v", staticDir, err)
 	}
 
-	packages, err := list(*c)
+	packages, err := list(c)
 	if err != nil {
 		return fmt.Errorf("cannot list packages: %v", err)
 	}
 
 	for _, pkg := range packages {
-		err := writePackage(*c, packages, pkg)
+		err := writePackage(c, packages, pkg)
 		if err != nil {
 			return fmt.Errorf("could not write package %v: %v", pkg.Name, err)
 		}
 	}
 
-	if err := makeIndexes(*c); err != nil {
+	if err := makeIndexes(c); err != nil {
 		return fmt.Errorf("could not generate index.html files: %v", err)
 	}
-	if err := makeHome(*c, packages); err != nil {
+	if err := makeHome(c, packages); err != nil {
 		return fmt.Errorf("could not generate index.html files: %v", err)
 	}
 
 	return nil
 }
 
-func parseConfig(opts options) (*Config, error) {
+func parseConfig(opts options) (Config, error) {
 	sconfig.RegisterType("[]main.group", func(v []string) (interface{}, error) {
 		g := group{Name: v[0]}
 
@@ -181,7 +181,7 @@ func parseConfig(opts options) (*Config, error) {
 	c := Config{}
 	err := sconfig.Parse(&c, opts.config, nil)
 	if err != nil {
-		return nil, err
+		return c, err
 	}
 	c.SkipClone = c.SkipClone || opts.skipClone
 
@@ -192,7 +192,7 @@ func parseConfig(opts options) (*Config, error) {
 			c.User = envUser
 		}
 		if c.User == "" {
-			return nil, errNoUser
+			return c, errNoUser
 		}
 
 		envPass := os.Getenv("GITHUB_PASS")
@@ -200,11 +200,11 @@ func parseConfig(opts options) (*Config, error) {
 			c.Pass = envPass
 		}
 		if c.Pass == "" {
-			return nil, errNoPass
+			return c, errNoPass
 		}
 	}
 
-	return &c, nil
+	return c, nil
 }
 
 func filterRepos(in []repository) []repository {

--- a/godocgen_test.go
+++ b/godocgen_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 )
@@ -19,7 +20,7 @@ func TestParseConfigWithoutEnvOverwrite(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Remove(mockConfigFile.Name())
+	defer cleanupConfigFile(mockConfigFile)
 
 	// Test body
 	config, err := parseConfig(options{config: mockConfigFile.Name()})
@@ -52,19 +53,19 @@ func TestParseConfigWithEnvOverwrite(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Remove(mockConfigFile.Name())
+	defer cleanupConfigFile(mockConfigFile)
 
 	err = os.Setenv("GITHUB_USER", mockEnvUser)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Setenv("GITHUB_USER", "")
 
 	err = os.Setenv("GITHUB_PASS", mockEnvPass)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Setenv("GITHUB_PASS", "")
+	defer cleanupEnvVars()
+
 	// Test body
 	config, err := parseConfig(options{config: mockConfigFile.Name()})
 	if err != nil {
@@ -87,7 +88,7 @@ func TestParseConfigNoUserError(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Remove(mockConfigFile.Name())
+	defer cleanupConfigFile(mockConfigFile)
 
 	// Test body
 	_, err = parseConfig(options{config: mockConfigFile.Name()})
@@ -105,7 +106,7 @@ func TestParseConfigNoPassError(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	defer os.Remove(mockConfigFile.Name())
+	defer cleanupConfigFile(mockConfigFile)
 
 	// Test body
 	_, err = parseConfig(options{config: mockConfigFile.Name()})
@@ -137,4 +138,23 @@ func createMockConfig(name string, values map[string]string) (*os.File, error) {
 	}
 
 	return file, nil
+}
+
+func cleanupConfigFile(f *os.File) {
+	err := os.Remove(f.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func cleanupEnvVars() {
+	err := os.Setenv("GITHUB_USER", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.Setenv("GITHUB_PASS", "")
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/godocgen_test.go
+++ b/godocgen_test.go
@@ -10,7 +10,6 @@ import (
 func TestParseConfigWithoutEnvOverwrite(t *testing.T) {
 	mockUser := "someGitUser"
 	mockPass := "someGitPass"
-
 	// Test preparation
 	mockConfValues := map[string]string{
 		"user": mockUser,
@@ -21,17 +20,14 @@ func TestParseConfigWithoutEnvOverwrite(t *testing.T) {
 		t.Errorf("expected no error, got %v", err)
 	}
 	defer cleanupConfigFile(mockConfigFile)
-
 	// Test body
 	config, err := parseConfig(options{config: mockConfigFile.Name()})
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-
 	if config.User != mockUser {
 		t.Errorf("expected config.User to be equal to config user")
 	}
-
 	if config.Pass != mockPass {
 		t.Errorf("expected config.Pass to be equal to config pass")
 	}
@@ -89,14 +85,12 @@ func TestParseConfigNoUserError(t *testing.T) {
 		t.Errorf("expected no error, got %v", err)
 	}
 	defer cleanupConfigFile(mockConfigFile)
-
 	// Test body
 	_, err = parseConfig(options{config: mockConfigFile.Name()})
 	if err != errNoUser {
 		t.Errorf("expected errNoUser, got %v", err)
 	}
 }
-
 func TestParseConfigNoPassError(t *testing.T) {
 	// Test preparation
 	mockConfValues := map[string]string{
@@ -107,14 +101,12 @@ func TestParseConfigNoPassError(t *testing.T) {
 		t.Errorf("expected no error, got %v", err)
 	}
 	defer cleanupConfigFile(mockConfigFile)
-
 	// Test body
 	_, err = parseConfig(options{config: mockConfigFile.Name()})
 	if err != errNoPass {
 		t.Errorf("expected errNoPass, got %v", err)
 	}
 }
-
 func TestParseConfigParseError(t *testing.T) {
 	_, err := parseConfig(options{config: "invalid_file"})
 	if err == nil {

--- a/godocgen_test.go
+++ b/godocgen_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestParseConfigWithoutEnvOverwrite(t *testing.T) {
+	mockUser := "someGitUser"
+	mockPass := "someGitPass"
+
+	// Test preparation
+	mockConfValues := map[string]string{
+		"user": mockUser,
+		"pass": mockPass,
+	}
+	mockConfigFile, err := createMockConfig("mock_config", mockConfValues)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Remove(mockConfigFile.Name())
+
+	// Test body
+	config, err := parseConfig(options{config: mockConfigFile.Name()})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if config.User != mockUser {
+		t.Errorf("expected config.User to be equal to config user")
+	}
+
+	if config.Pass != mockPass {
+		t.Errorf("expected config.Pass to be equal to config pass")
+	}
+}
+
+func TestParseConfigWithEnvOverwrite(t *testing.T) {
+	mockUser := "someGitUser"
+	mockPass := "someGitPass"
+
+	mockEnvUser := "someEnvGitUser"
+	mockEnvPass := "someEnvGitPass"
+
+	// Test preparation
+	mockConfValues := map[string]string{
+		"user": mockUser,
+		"pass": mockPass,
+	}
+	mockConfigFile, err := createMockConfig("mock_config", mockConfValues)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Remove(mockConfigFile.Name())
+
+	err = os.Setenv("GITHUB_USER", mockEnvUser)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Setenv("GITHUB_USER", "")
+
+	err = os.Setenv("GITHUB_PASS", mockEnvPass)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Setenv("GITHUB_PASS", "")
+	// Test body
+	config, err := parseConfig(options{config: mockConfigFile.Name()})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if config.User != mockEnvUser {
+		t.Errorf("expected config.User to be equal to env user")
+	}
+
+	if config.Pass != mockEnvPass {
+		t.Errorf("expected config.Pass to be equal to env pass")
+	}
+}
+
+func TestParseConfigNoUserError(t *testing.T) {
+	// Test preparation
+	mockConfValues := map[string]string{}
+	mockConfigFile, err := createMockConfig("mock_config", mockConfValues)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Remove(mockConfigFile.Name())
+
+	// Test body
+	_, err = parseConfig(options{config: mockConfigFile.Name()})
+	if err != errNoUser {
+		t.Errorf("expected errNoUser, got %v", err)
+	}
+}
+
+func TestParseConfigNoPassError(t *testing.T) {
+	// Test preparation
+	mockConfValues := map[string]string{
+		"user": "someUser",
+	}
+	mockConfigFile, err := createMockConfig("mock_config", mockConfValues)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	defer os.Remove(mockConfigFile.Name())
+
+	// Test body
+	_, err = parseConfig(options{config: mockConfigFile.Name()})
+	if err != errNoPass {
+		t.Errorf("expected errNoPass, got %v", err)
+	}
+}
+
+func TestParseConfigParseError(t *testing.T) {
+	_, err := parseConfig(options{config: "invalid_file"})
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}
+
+// Helper function that creates a temporary config file
+func createMockConfig(name string, values map[string]string) (*os.File, error) {
+	file, err := ioutil.TempFile(os.TempDir(), name)
+	if err != nil {
+		return nil, err
+	}
+	conf := ""
+	for key, value := range values {
+		conf = conf + key + " " + value + "\n"
+	}
+	_, err = file.Write([]byte(conf))
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
This PR brings the following changes:

* Small refactoring so the changes can be unit tested
* The env vars `GITHUB_USER` and `GITHUB_PASS` will overwrite the ones defined in the configuration

Closes #17 